### PR TITLE
Import RPi BGRX video frames as opaque X11 pixmaps

### DIFF
--- a/debian/patches/rpi/0021-X11-Import-BGRX-native-pixmaps-as-opaque-RGB.patch
+++ b/debian/patches/rpi/0021-X11-Import-BGRX-native-pixmaps-as-opaque-RGB.patch
@@ -1,0 +1,104 @@
+Description: Import BGRX native pixmaps as opaque RGB textures on X11
+ Raspberry Pi's bcm2835-codec exposes decoded BGR4 buffers as B,G,R,X bytes,
+ which Chromium correctly represents as XRGB/BGRX.  When dma-buf EGL import is
+ unavailable, Ozone X11 falls back through a DRI3 X pixmap, but that binding
+ only accepts BGRA and always binds it as EGL_TEXTURE_RGBA.  Accept BGRX in
+ that X11-only fallback and bind it as EGL_TEXTURE_RGB so the undefined X byte
+ is ignored and sampled alpha is one.  BGRA keeps its existing RGBA path.
+Author: Tian Zheng <naitgnehz@gmail.com>
+Bug: https://github.com/RPi-Distro/chromium/issues/61
+Forwarded: https://github.com/RPi-Distro/chromium/issues/61
+Last-Update: 2026-07-12
+
+--- a/ui/ozone/platform/x11/native_pixmap_egl_x11_binding.cc
++++ b/ui/ozone/platform/x11/native_pixmap_egl_x11_binding.cc
+@@ -20,7 +20,8 @@ namespace gl {
+ namespace {
+ bool IsFormatSupported(viz::SharedImageFormat format) {
+-  // Only supports BGRA_8888 format.
+-  return format == viz::SinglePlaneFormat::kBGRA_8888;
++  // The X11 pixmap path uses the same 32-bit storage for BGRA and BGRX.
++  return format == viz::SinglePlaneFormat::kBGRA_8888 ||
++         format == viz::SinglePlaneFormat::kBGRX_8888;
+ }
+ 
+ x11::Pixmap XPixmapFromNativePixmap(const gfx::NativePixmap& native_pixmap) {
+@@ -28,4 +29,7 @@ x11::Pixmap XPixmapFromNativePixmap(cons
+-  const uint8_t depth = 32;
++  const auto format = native_pixmap.GetSharedImageFormat();
++  CHECK(IsFormatSupported(format));
++  const uint8_t depth =
++      format == viz::SinglePlaneFormat::kBGRX_8888 ? 24 : 32;
+   const uint8_t bpp = 32;
+   const auto fd = HANDLE_EINTR(dup(native_pixmap.GetDmaBufFd(0)));
+   if (fd < 0) {
+@@ -133,8 +137,11 @@ bool NativePixmapEGLX11Binding::IsShared
+   return gl::IsFormatSupported(format);
+ }
+ 
+-bool NativePixmapEGLX11Binding::Initialize(x11::Pixmap pixmap) {
++bool NativePixmapEGLX11Binding::Initialize(
++    x11::Pixmap pixmap,
++    viz::SharedImageFormat format) {
+   CHECK_NE(pixmap, x11::Pixmap::None);
++  CHECK(gl::IsFormatSupported(format));
+   pixmap_ = pixmap;
+ 
+   if (eglInitialize(display_, nullptr, nullptr) != EGL_TRUE) {
+@@ -142,6 +149,15 @@ bool NativePixmapEGLX11Binding::Initiali
+     return false;
+   }
+ 
++  // BGRX uses a depth-24/bpp-32 X pixmap: its fourth byte is undefined
++  // padding. Binding it as RGB makes EGL/GL ignore that byte and return
++  // alpha=1 instead of exposing it as texture alpha.
++  const EGLint texture_format =
++      format == viz::SinglePlaneFormat::kBGRX_8888 ? EGL_TEXTURE_RGB
++                                                    : EGL_TEXTURE_RGBA;
++  const EGLint bind_to_texture =
++      format == viz::SinglePlaneFormat::kBGRX_8888 ? EGL_BIND_TO_TEXTURE_RGB
++                                                    : EGL_BIND_TO_TEXTURE_RGBA;
+   EGLint attribs[] = {EGL_BUFFER_SIZE,
+                       32,
+                       EGL_ALPHA_SIZE,
+@@ -158,7 +174,7 @@ bool NativePixmapEGLX11Binding::Initiali
+                       8,
+                       EGL_SURFACE_TYPE,
+                       EGL_PIXMAP_BIT,
+-                      EGL_BIND_TO_TEXTURE_RGBA,
++                      bind_to_texture,
+                       EGL_TRUE,
+                       EGL_NONE};
+ 
+@@ -166,8 +182,8 @@ bool NativePixmapEGLX11Binding::Initiali
+     return false;
+   }
+ 
+-  std::vector<EGLint> attrs = {EGL_TEXTURE_FORMAT, EGL_TEXTURE_RGBA,
+-                               EGL_TEXTURE_TARGET, EGL_TEXTURE_2D, EGL_NONE};
++  std::vector<EGLint> attrs = {EGL_TEXTURE_FORMAT, texture_format,
++                               EGL_TEXTURE_TARGET, EGL_TEXTURE_2D, EGL_NONE};
+ 
+   surface_ = eglCreatePixmapSurface(
+       display_, config, static_cast<EGLNativePixmapType>(pixmap), attrs.data());
+@@ -209,7 +225,7 @@ std::unique_ptr<NativePixmapGLBinding> Na
+   }
+ 
+   // Transfer the ownership of `pixmap` to `NativePixmapEGLX11Binding`.
+-  if (!binding->Initialize(std::move(pixmap))) {
++  if (!binding->Initialize(std::move(pixmap), plane_format)) {
+     VLOG(1) << "Unable to initialize binding from pixmap";
+     return nullptr;
+   }
+--- a/ui/ozone/platform/x11/native_pixmap_egl_x11_binding.h
++++ b/ui/ozone/platform/x11/native_pixmap_egl_x11_binding.h
+@@ -38,7 +38,8 @@ class NativePixmapEGLX11Binding : public
+   static bool CanImportNativeGLXPixmap();
+ 
+  private:
+-  bool Initialize(x11::Pixmap pixmap);
++  bool Initialize(x11::Pixmap pixmap,
++                  viz::SharedImageFormat format);
+ 
+   // Binds image to texture currently bound to |target|. Returns true on
+   // success.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -265,3 +265,4 @@ rpi/v4l2_startup.patch
 rpi/background-mode.patch
 rpi/0018-base-Use-udf-for-ImmediateCrash-on-ARMv7.patch
 rpi/0019-gl-Disable-FallbackToSWIfGLES3NotSupported.patch
+rpi/0021-X11-Import-BGRX-native-pixmaps-as-opaque-RGB.patch


### PR DESCRIPTION
## What changed

Add an X11-only Debian patch that imports `kBGRX_8888` native pixmaps as opaque RGB textures:

- allow BGRX in `NativePixmapEGLX11Binding`;
- create a depth-24, bpp-32 X pixmap for BGRX;
- select an RGB-bindable EGL config and use `EGL_TEXTURE_RGB`;
- keep the existing depth-32/`EGL_TEXTURE_RGBA` path for BGRA.

Wayland and direct dma-buf import paths are not changed.

## Why

The Raspberry Pi stateful V4L2 decoder exposes BGR4 buffers as B, G, R, X. The fourth byte is undefined padding, not alpha. Binding that storage as RGBA can expose the padding byte as texture alpha.

A focused ANGLE/GLX readback showed:

| X pixmap / EGL target | RGBA readback |
| --- | --- |
| depth 24, bpp 32 / `EGL_TEXTURE_RGB` | `[17, 34, 51, 255]` |
| depth 32, bpp 32 / `EGL_TEXTURE_RGBA` | `[17, 34, 51, 0]` |
| depth 32, bpp 32 / `EGL_TEXTURE_RGB` | `[0, 0, 0, 255]` |

Tracks #61. This is adjacent to #57 but targets a different, directly reproduced BGRX padding/alpha path.

## Validation

- The focused Ozone X11 target compiles with the patch on the pinned Chromium 150 source.
- The ANGLE/GLX pixel readback above confirms the required depth/texture-format combination.
- A diagnostic V4L2 run produced visually correct colors, but it used a temporary sandbox bypass and is not acceptable deployment evidence.
- The complete armhf build and sandboxed Pi 3 canary, including screenshots and 30-minute playback, are still in progress.

This PR remains a draft until the safe on-device canary is complete. The same source-level behavior may ultimately belong upstream in Chromium Gerrit; this packaging patch provides a reviewable Raspberry Pi backport in the meantime.

