### PR TITLE
Fix host tool selection in armhf cross builds

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Build-Depends:
  rustc:any (>= 1.84),
  libstd-rust-dev (>= 1.84),
  bindgen:native,
- rustfmt,
+ rustfmt:native,
  python3:any,
  pkgconf,
  ninja-build,

--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,7 @@ Build-Depends:
  nodejs:any,
  node-rollup-plugin-terser:native,
  rollup,
- esbuild,
+ esbuild:native,
  xz-utils,
  xcb-proto,
  xfonts-base,

--- a/debian/patches/debianization/cross-build-dump-syms.patch
+++ b/debian/patches/debianization/cross-build-dump-syms.patch
@@ -1,0 +1,28 @@
+Description: Run Breakpad dump_syms through the Debian cross wrapper
+ Chromium's Linux symbol actions build dump_syms with the configured host
+ CPU, which Raspberry Pi's single-toolchain cross build sets to armhf.  The
+ dump_app_syms.py runner executes that target binary directly on the x86-64
+ builder.  Honor HOST_EXEC_WRAPPER for dump_syms only; the later strip command
+ remains a native build-host tool.
+Author: Tian Zheng <naitgnehz@gmail.com>
+Bug: https://github.com/RPi-Distro/chromium/issues/62
+Forwarded: https://github.com/RPi-Distro/chromium/issues/62
+Last-Update: 2026-07-12
+
+--- a/build/linux/dump_app_syms.py
++++ b/build/linux/dump_app_syms.py
+@@ -24,9 +24,13 @@ outfile = sys.argv[4]
+ # Dump only when the output file is out-of-date.
+ if not os.path.isfile(outfile) or \
+    os.stat(outfile).st_mtime < os.stat(infile).st_mtime:
++  dump_syms_cmd = [dumpsyms, '-m', '-d', infile]
++  wrapper_env = os.environ.get('HOST_EXEC_WRAPPER')
++  if wrapper_env:
++    dump_syms_cmd[0:0] = wrapper_env.split()
+   try:
+     with open(outfile, 'w') as outfileobj:
+-      subprocess.check_call([dumpsyms, '-m', '-d', infile], stdout=outfileobj)
++      subprocess.check_call(dump_syms_cmd, stdout=outfileobj)
+   except:
+     # Remove the output file on failure to make the build step atomic.
+     if os.path.isfile(outfile):

--- a/debian/patches/debianization/cross-build-perfetto-run-binary.patch
+++ b/debian/patches/debianization/cross-build-perfetto-run-binary.patch
@@ -1,0 +1,25 @@
+Description: Run Perfetto build tools through the Debian cross wrapper
+ Perfetto's run_binary.py was added after Debian's general Chromium
+ cross-build patch and invokes target-architecture generators directly.
+ Honor HOST_EXEC_WRAPPER like the other build runners so armhf tools execute
+ through cross-exe-wrapper/QEMU on the native build host.
+Author: Tian Zheng <naitgnehz@gmail.com>
+Bug: https://github.com/RPi-Distro/chromium/issues/62
+Forwarded: https://github.com/RPi-Distro/chromium/issues/62
+Last-Update: 2026-07-12
+
+--- a/third_party/perfetto/gn/run_binary.py
++++ b/third_party/perfetto/gn/run_binary.py
+@@ -17,6 +17,11 @@ This script exists because GN action onl
+ 
++import os
+ import sys
+ import subprocess
+ 
+ if __name__ == '__main__':
+-  sys.exit(subprocess.call(sys.argv[1:]))
++  args = sys.argv[1:]
++  wrapper_env = os.environ.get('HOST_EXEC_WRAPPER')
++  if wrapper_env:
++    args[0:0] = wrapper_env.split()
++  sys.exit(subprocess.call(args))

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,6 +5,7 @@ debianization/clang-version.patch
 debianization/swiftshader-use-llvm-16.patch
 debianization/cross-build.patch
 debianization/cross-build-perfetto-run-binary.patch
+debianization/cross-build-dump-syms.patch
 debianization/rustc-bootstrap.patch
 debianization/safe-libcxx.patch
 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,6 +4,7 @@ debianization/sandbox.patch
 debianization/clang-version.patch
 debianization/swiftshader-use-llvm-16.patch
 debianization/cross-build.patch
+debianization/cross-build-perfetto-run-binary.patch
 debianization/rustc-bootstrap.patch
 debianization/safe-libcxx.patch
 


### PR DESCRIPTION
## What changed

Fix four host/target mismatches in the armhf cross-build path, as four focused commits:

1. select `esbuild:native` because the build host executes esbuild;
2. select `rustfmt:native` because source generation executes rustfmt;
3. make Perfetto's `run_binary.py` prepend `HOST_EXEC_WRAPPER` when set;
4. make `dump_app_syms.py` wrap the target `dump_syms` binary while leaving the later system `strip` command native.

Tracks #62.

## Why

With `dpkg-buildpackage -B --host-arch armhf -Pcross` on an x86-64 Trixie builder, unqualified build-tool dependencies resolve to armhf and cannot be executed natively. Chromium 150 also has runners that execute generated armhf helpers without the `cross-exe-wrapper` path already used elsewhere in the Debian packaging.

These changes affect build dependencies and build-time process launching only; they do not change Chromium runtime behavior.

## Validation

- cross-profile dependency resolution was checked for esbuild and rustfmt;
- both Python patches pass syntax checks;
- command-level smoke tests confirm `HOST_EXEC_WRAPPER` is applied to the intended target binary;
- the real armhf package build has progressed past the original esbuild, rustfmt, and Perfetto failures;
- the complete package build, including the final Breakpad symbol action and `.deb` output, is still running.

This PR is intentionally a draft. I will add the final armhf package result before marking it ready. The four commits can be split into separate PRs if that is easier to review.

